### PR TITLE
Changed all float complex instances to SUCOMPLEX

### DIFF
--- a/Misc/FileDataSaver.cpp
+++ b/Misc/FileDataSaver.cpp
@@ -34,7 +34,7 @@ namespace SigDigger {
     bool prepare(void);
     bool canWrite(void) const;
     std::string getError(void) const;
-    ssize_t write(const float _Complex *data, size_t len);
+    ssize_t write(const SUCOMPLEX *data, size_t len);
     bool close(void);
     ~FileDataWriter();
   };
@@ -64,7 +64,7 @@ FileDataWriter::canWrite(void) const
 }
 
 ssize_t
-FileDataWriter::write(const float _Complex *data, size_t len)
+FileDataWriter::write(const SUCOMPLEX *data, size_t len)
 {
   ssize_t result;
 

--- a/Misc/GenericDataSaver.cpp
+++ b/Misc/GenericDataSaver.cpp
@@ -56,9 +56,9 @@ GenericDataWorker::onCommit(void)
     struct timeval tv, otv, sub;
     ssize_t dumped;
     size_t allocation = this->instance->allocation;
-    std::vector<float _Complex> *thisBuf =
+    std::vector<SUCOMPLEX> *thisBuf =
         &this->instance->buffers[1 - this->instance->buffer];
-    float _Complex *buffer = thisBuf->data();
+    SUCOMPLEX *buffer = thisBuf->data();
     int remaining = static_cast<int>(this->instance->commitedSize);
 
     locker.unlock();
@@ -207,7 +207,7 @@ GenericDataSaver::setBufferSize(unsigned int size)
 }
 
 void
-GenericDataSaver::write(const float _Complex *data, size_t size)
+GenericDataSaver::write(const SUCOMPLEX *data, size_t size)
 {
   if (this->writer->canWrite()) {
     QMutexLocker locker(&this->dataMutex);
@@ -225,7 +225,7 @@ GenericDataSaver::write(const float _Complex *data, size_t size)
     memcpy(
       this->buffers[this->buffer].data() + this->ptr,
       data,
-      size * sizeof(float _Complex));
+      size * sizeof(SUCOMPLEX));
 
     this->ptr += size;
 

--- a/UDP/SocketForwarder.cpp
+++ b/UDP/SocketForwarder.cpp
@@ -23,6 +23,10 @@
 #include <netdb.h>
 #include <stdexcept>
 
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
 using namespace SigDigger;
 
 namespace SigDigger {
@@ -48,7 +52,7 @@ namespace SigDigger {
     bool prepare(void) override;
     std::string getError(void) const override;
     bool canWrite(void) const override;
-    ssize_t write(const float _Complex *data, size_t len) override;
+    ssize_t write(const SUCOMPLEX *data, size_t len) override;
     bool close(void) override;
     ~SocketDataWriter() override;
   };
@@ -59,7 +63,7 @@ SocketDataWriter::SocketDataWriter(
     uint16_t port,
     unsigned int size,
     bool tcp) :
-  host(host), port(port), tcp(tcp), size(size / sizeof(float _Complex))
+  host(host), port(port), tcp(tcp), size(size / sizeof(SUCOMPLEX))
 {
   this->pad[0] = this->pad2[0] = 0; // Shut up
 }
@@ -116,7 +120,7 @@ SocketDataWriter::canWrite(void) const
 }
 
 ssize_t
-SocketDataWriter::write(const float _Complex *data, size_t len)
+SocketDataWriter::write(const SUCOMPLEX *data, size_t len)
 {
   ssize_t sent;
 
@@ -126,7 +130,7 @@ SocketDataWriter::write(const float _Complex *data, size_t len)
   sent = sendto(
           this->fd,
           data,
-          static_cast<size_t>(len) * sizeof(float _Complex),
+          static_cast<size_t>(len) * sizeof(SUCOMPLEX),
           MSG_NOSIGNAL,
           reinterpret_cast<struct sockaddr *>(&this->addr),
           sizeof(struct sockaddr_in));
@@ -135,7 +139,7 @@ SocketDataWriter::write(const float _Complex *data, size_t len)
     this->lastError = std::string(strerror(errno));
 
 
-  sent /= static_cast<ssize_t>(sizeof(float _Complex));
+  sent /= static_cast<ssize_t>(sizeof(SUCOMPLEX));
 
 
   return sent;

--- a/include/GenericDataSaver.h
+++ b/include/GenericDataSaver.h
@@ -36,7 +36,7 @@ namespace SigDigger {
   public:
     virtual bool prepare(void) = 0;
     virtual bool canWrite(void) const = 0;
-    virtual ssize_t write(const float _Complex *data, size_t len) = 0;
+    virtual ssize_t write(const SUCOMPLEX *data, size_t len) = 0;
     virtual bool close(void) = 0;
     virtual std::string getError(void) const = 0;
     virtual ~GenericDataWriter();
@@ -66,7 +66,7 @@ namespace SigDigger {
   {
       Q_OBJECT
 
-      std::vector<float _Complex>buffers[2];
+      std::vector<SUCOMPLEX>buffers[2];
       QString lastError;
 
       unsigned int rateHint;
@@ -100,7 +100,7 @@ namespace SigDigger {
       // Public methods
       void setBufferSize(unsigned int size);
       void setSampleRate(unsigned int i);
-      void write(const float _Complex *data, size_t size);
+      void write(const SUCOMPLEX *data, size_t size);
       QString getLastError(void) const;
       quint64 getSize(void) const;
 


### PR DESCRIPTION
We should use Sigutil's macros like SUCOMPLEX to be cross platform.
I fixed them.
Also, there's no `MSG_NOSIGNAL` in OS X.