### PR TITLE
Fix missing lock guard

### DIFF
--- a/Suscan/Logger.cpp
+++ b/Suscan/Logger.cpp
@@ -55,14 +55,14 @@ Logger::push(const struct sigutils_log_message *message)
   msg.function = std::string(message->function);
   msg.message  = std::string(message->message);
 
-  std::lock_guard<std::mutex>(this->mutex);
+  std::lock_guard<std::mutex> lock(this->mutex);
   this->messages.push_back(std::move(msg));
 }
 
 void
 Logger::flush(void)
 {
-  std::lock_guard<std::mutex>(this->mutex);
+  std::lock_guard<std::mutex> lock(this->mutex);
   this->messages.clear();
 }
 


### PR DESCRIPTION
This commit fixes a bug where the lock guard (for concurrently accessing
the same scope from different threads) had basically no effect, due to
being bound to a temporary only.