### PR TITLE
App & Audio: use sizeof for snprintf buffer size

### DIFF
--- a/App/Application.cpp
+++ b/App/Application.cpp
@@ -1146,7 +1146,7 @@ Application::openCaptureFile(void)
 
   snprintf(
         baseName,
-        64,
+        sizeof(baseName),
         "sigdigger_%d_%.0lf_float32_iq.raw",
         this->mediator->getProfile()->getDecimatedSampleRate(),
         this->mediator->getProfile()->getFreq());

--- a/Audio/AudioFileSaver.cpp
+++ b/Audio/AudioFileSaver.cpp
@@ -75,8 +75,6 @@ AudioFileWriter::prepare(void)
         break;
     }
 
-    fileName[127] = '\0';
-
     do {
       snprintf(
             fileName,

--- a/Audio/AudioFileSaver.cpp
+++ b/Audio/AudioFileSaver.cpp
@@ -80,7 +80,7 @@ AudioFileWriter::prepare(void)
     do {
       snprintf(
             fileName,
-            127,
+            sizeof(fileName),
             "audio-%s-%.0lf-%d-%04d.wav",
             modulation.c_str(),
             this->params.frequency,


### PR DESCRIPTION
This way snprintf always gets the correct buffer size.