### PR TITLE
Include UTC timestamp in sigdigger_*.raw IQ recording filenames

### DIFF
--- a/App/Application.cpp
+++ b/App/Application.cpp
@@ -1136,18 +1136,26 @@ Application::onThrottleConfigChanged(void)
 }
 
 //
-// sigdigger_XXXXXXXXXX_XXXXXXXXXXXXXXXXXXXX_float32_iq.raw
+// sigdigger_XXXXXXXX_XXXXXXZ_XXXXXXXXXX_XXXXXXXXXXXXXXXXXXXX_float32_iq.raw
 //
 int
 Application::openCaptureFile(void)
 {
   int fd = -1;
-  char baseName[64];
+  char baseName[80];
+  char datetime[17];
+  time_t unixtime;
+  struct tm tm;
+
+  unixtime = time(NULL);
+  gmtime_r(&unixtime, &tm);
+  strftime(datetime, sizeof(datetime), "%Y%m%d_%H%M%SZ", &tm);
 
   snprintf(
         baseName,
         sizeof(baseName),
-        "sigdigger_%d_%.0lf_float32_iq.raw",
+        "sigdigger_%s_%d_%.0lf_float32_iq.raw",
+        datetime,
         this->mediator->getProfile()->getDecimatedSampleRate(),
         this->mediator->getProfile()->getFreq());
 

--- a/Components/ConfigDialog.cpp
+++ b/Components/ConfigDialog.cpp
@@ -749,6 +749,15 @@ ConfigDialog::guessParamsFromFileName(void)
 
   if (sscanf(
         baseName.c_str(),
+        "sigdigger_%08d_%06dZ_%d_%lg_float32_iq",
+        &date,
+        &time,
+        &fs,
+        &fc) == 4) {
+    haveFc = true;
+    haveFs = true;
+  } else if (sscanf(
+        baseName.c_str(),
         "sigdigger_%d_%lg_float32_iq",
         &fs,
         &fc) == 2) {


### PR DESCRIPTION
This prevents accidentally losing data by clicking record when using a
recording folder that already contains a recording with the same center
frequency and sample rate (and therefore same filename).

The useful usage pattern this commit enables is being able to
record/stop recording repeatedly without having to manually rename the
last recording or changing the recording folder.  (Starting and stopping
the recording repeatedly within the same second will still lead to
potential data loss.)