### PR TITLE
Components: allow any power of 2 FFT size between 512 and 1M

### DIFF
--- a/Components/FftPanel.cpp
+++ b/Components/FftPanel.cpp
@@ -187,10 +187,8 @@ FftPanel::FftPanel(QWidget *parent) :
 
   this->assertConfig();
 
-  for (i = 9; i < 17; ++i)
+  for (i = 9; i < 21; ++i)
     this->addFftSize(1 << i);
-
-  this->addFftSize(1 << 20);
 
   // Add refresh rates
   this->addRefreshRate(1);


### PR DESCRIPTION
I'm not really sure why there was a gap in the sizes. I found 256k and 512k useful since they aren't as slow as 1M, but still give nice detail.