### PR TITLE
Suscan: fix signed/unsigned comparison warning

### DIFF
--- a/Suscan/Config.cpp
+++ b/Suscan/Config.cpp
@@ -41,7 +41,7 @@ void
 Config::populate(void)
 {
   if (instance != nullptr)
-    for (int i = 0; i < instance->desc->field_count; ++i)
+    for (unsigned int i = 0; i < instance->desc->field_count; ++i)
       this->fields.push_back(FieldValue(instance->values[i]));
 }
 


### PR DESCRIPTION
Two of the 3 loops want a signed index while the third wants an unsigned
one.  The simplest way around this is to define the index variable
inside each loop.