### PR TITLE
fix segfault in UIMediator

### DIFF
--- a/UIMediator/InspectorMediator.cpp
+++ b/UIMediator/InspectorMediator.cpp
@@ -99,8 +99,10 @@ UIMediator::detachAllInspectors()
   for (auto p = this->ui->inspectorTable.begin();
        p != this->ui->inspectorTable.end();
        ++p) {
-    p->second->setAnalyzer(nullptr);
-    p->second = nullptr;
+    if (p->second) {
+      p->second->setAnalyzer(nullptr);
+      p->second = nullptr;
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes a segfault due to `nullptr` dereference.

I don't understand the program logic, so a proper fix may or may not require deeper redesign.

Steps to reproduce the segfault (at least on my computer...):

 * Use a file source
 * Select a channel (frequency band) 
 * Click on Run button
 * Open ASK inspector from Inspector tab.
 * Click on Run button twice (or more times?)


