### PR TITLE
Report coverage in FFT widget

### DIFF
--- a/Default/FFT/FFTWidget.cpp
+++ b/Default/FFT/FFTWidget.cpp
@@ -536,7 +536,7 @@ void
 FFTWidget::updateRbw()
 {
   if (m_rate == 0 || m_fftSize == 0) {
-    m_ui->rbwLabel->setText("RBW: N/A");
+    m_ui->rbwLabel->setText("N/A");
   } else {
     qreal rbw = static_cast<qreal>(m_rate) / m_fftSize;
     QString rbwString = SuWidgetsHelpers::formatQuantity(
@@ -544,7 +544,7 @@ FFTWidget::updateRbw()
           2,
           QStringLiteral("Hz"));
 
-    m_ui->rbwLabel->setText("RBW: " + rbwString);
+    m_ui->rbwLabel->setText(rbwString);
   }
 }
 

--- a/Default/FFT/FFTWidget.cpp
+++ b/Default/FFT/FFTWidget.cpp
@@ -183,6 +183,7 @@ FFTWidget::setProfile(Suscan::Source::Config &config)
 {
   m_rate = config.getDecimatedSampleRate();
   updateRbw();
+  updateCoverage();
 }
 
 void
@@ -548,6 +549,19 @@ FFTWidget::updateRbw()
   }
 }
 
+void
+FFTWidget::updateCoverage()
+{
+  if (m_rate == 0 || m_fftSize == 0 || m_refreshRate == 0) {
+    m_ui->coverageLabel->setText("N/A");
+  } else {
+    qreal coverage = static_cast<qreal>(m_refreshRate * m_fftSize) / m_rate;
+    QString coverageString = QString("%1\%").arg(100 * coverage, 0, 'f', 1);
+
+    m_ui->coverageLabel->setText(coverageString);
+  }
+}
+
 FFTWidget::~FFTWidget()
 {
   delete m_ui;
@@ -844,6 +858,7 @@ FFTWidget::setFftSize(unsigned int size)
 {
   m_fftSize = size;
   updateRbw();
+  updateCoverage();
   updateFftSizes();
 }
 
@@ -852,6 +867,7 @@ FFTWidget::setRefreshRate(unsigned int rate)
 {
   m_refreshRate = rate;
   updateRefreshRates();
+  updateCoverage();
 }
 
 void
@@ -881,6 +897,7 @@ FFTWidget::setSampleRate(unsigned int rate)
 {
   m_rate = rate;
   updateRbw();
+  updateCoverage();
 }
 
 void
@@ -1164,6 +1181,7 @@ FFTWidget::onFftSizeChanged()
     m_fftSize = m_defaultFftSize;
 
   updateRbw();
+  updateCoverage();
 
   params->windowSize = getFftSize();
 
@@ -1181,6 +1199,8 @@ FFTWidget::onRefreshRateChanged()
 
   if (m_refreshRate == 0)
     m_refreshRate = m_defaultRefreshRate;
+
+  updateCoverage();
 
   params->psdUpdateInterval = 1.f / getRefreshRate();
 
@@ -1324,6 +1344,7 @@ FFTWidget::onSourceInfoMessage(Suscan::SourceInfoMessage const &msg)
 {
   m_rate = SCAST(unsigned, msg.info()->getSampleRate());
   updateRbw();
+  updateCoverage();
 }
 
 void

--- a/Default/FFT/FFTWidget.h
+++ b/Default/FFT/FFTWidget.h
@@ -113,6 +113,7 @@ namespace SigDigger {
     void connectAll();
     void populateUnits();
     void updateRbw();
+    void updateCoverage();
 
     void refreshPalettes();
 

--- a/Default/FFT/FFTWidget.ui
+++ b/Default/FFT/FFTWidget.ui
@@ -29,7 +29,7 @@
    <property name="spacing">
     <number>3</number>
    </property>
-   <item row="17" column="0">
+   <item row="18" column="0">
     <widget class="QLabel" name="label_14">
      <property name="text">
       <string>Timezone</string>
@@ -39,23 +39,67 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
-    <widget class="QSlider" name="fftAspectSlider">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="value">
-      <number>30</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
+   <item row="17" column="0" colspan="3">
+    <widget class="QWidget" name="widget_2" native="true">
+     <layout class="QGridLayout" name="gridLayout_5">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="horizontalSpacing">
+       <number>1</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>0</number>
+      </property>
+      <item row="0" column="3">
+       <widget class="QPushButton" name="timeStampsButton">
+        <property name="text">
+         <string>&amp;Time stamps</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QPushButton" name="bookmarksButton">
+        <property name="text">
+         <string>&amp;Bookmarks</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="channelButton">
+        <property name="text">
+         <string>&amp;Channels</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_7">
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Averaging</string>
+      <string>Window</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -63,19 +107,117 @@
     </widget>
    </item>
    <item row="11" column="0">
-    <widget class="QLabel" name="label_9">
+    <widget class="QLabel" name="label_8">
      <property name="text">
-      <string>Peak</string>
+      <string>Spect/Wf</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="19" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="text">
+      <string>Freq zoom</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="fftSizeCombo">
+     <item>
+      <property name="text">
+       <string>Default</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>512</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>1024</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>2048</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>4096</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>8192</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>16384</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>32768</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>65536</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="1">
     <widget class="QComboBox" name="timeSpanCombo">
      <property name="enabled">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="1">
+    <widget class="QSlider" name="freqZoomSlider">
+     <property name="minimum">
+      <number>-900</number>
+     </property>
+     <property name="maximum">
+      <number>900</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="2">
+    <widget class="QLabel" name="freqZoomLabel">
+     <property name="minimumSize">
+      <size>
+       <width>31</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>1x</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Rate</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -89,74 +231,101 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="rateCombo">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <item>
-      <property name="text">
-       <string>1 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>5 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>10 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>15 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>20 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>30 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>50 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>60 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>90 fps</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>120 fps</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="20" column="0">
-    <widget class="QLabel" name="label_18">
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_13">
      <property name="text">
-      <string>Click res.</string>
+      <string>Gain</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="20" column="1">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>FFT size</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Units</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Peak</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="ContextAwareSpinBox" name="zeroPointSpin">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="suffix">
+      <string> dBFS</string>
+     </property>
+     <property name="minimum">
+      <double>-300.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>300.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="ContextAwareSpinBox" name="gainSpinBox">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="suffix">
+      <string> dB</string>
+     </property>
+     <property name="minimum">
+      <double>-300.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>300.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="ctkRangeSlider" name="pandRange">
+     <property name="minimum">
+      <number>-160</number>
+     </property>
+     <property name="maximum">
+      <number>40</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="minimumValue" stdset="0">
+      <number>-70</number>
+     </property>
+     <property name="minimumPosition" stdset="0">
+      <number>-70</number>
+     </property>
+     <property name="maximumPosition" stdset="0">
+      <number>-10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="1">
     <widget class="QComboBox" name="clickResCombo">
      <property name="enabled">
       <bool>true</bool>
@@ -221,6 +390,339 @@
        <string>10 MHz</string>
       </property>
      </item>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="rateCombo">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <item>
+      <property name="text">
+       <string>1 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>5 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>10 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>15 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>20 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>30 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>50 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>60 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>90 fps</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>120 fps</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Averaging</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QComboBox" name="windowCombo">
+     <item>
+      <property name="text">
+       <string>Rectangular</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Hamming</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Hann</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Flat-top</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Blackmann-Harris</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <widget class="ctkRangeSlider" name="wfRange">
+     <property name="minimum">
+      <number>-160</number>
+     </property>
+     <property name="maximum">
+      <number>40</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="minimumValue" stdset="0">
+      <number>-70</number>
+     </property>
+     <property name="maximumPosition" stdset="0">
+      <number>-10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="0">
+    <widget class="QLabel" name="label_17">
+     <property name="text">
+      <string>Palette</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="1">
+    <widget class="QComboBox" name="paletteCombo">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>64</width>
+       <height>20</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="0">
+    <widget class="QLabel" name="label_18">
+     <property name="text">
+      <string>Click res.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="1">
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="spacing">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Wf. dB</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="text">
+      <string>RBW</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QWidget" name="widget_3" native="true">
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="horizontalSpacing">
+       <number>3</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="SciSpinBox" name="avgSpinBox" native="true">
+        <property name="minimum" stdset="0">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="maximum" stdset="0">
+         <double>1000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_15">
+        <property name="text">
+         <string>FFTs</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="18" column="1">
+    <widget class="QComboBox" name="timeZoneCombo">
+     <item>
+      <property name="text">
+       <string>Local time</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Universal Time (UTC)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <widget class="QSlider" name="fftAspectSlider">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>30</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
+    <widget class="QWidget" name="widget_4" native="true">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>42</height>
+      </size>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QPushButton" name="detectPeakButton">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>&amp;Detect</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="holdPeakButton">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>&amp;Hold</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Zero adjust</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="1" colspan="2">
+    <widget class="QCheckBox" name="lockButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>&amp;Lock spectrum and waterfall</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="0" column="0" colspan="3">
@@ -304,448 +806,7 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QComboBox" name="windowCombo">
-     <item>
-      <property name="text">
-       <string>Rectangular</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Hamming</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Hann</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Flat-top</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Blackmann-Harris</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Rate</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="ContextAwareSpinBox" name="gainSpinBox">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="suffix">
-      <string> dB</string>
-     </property>
-     <property name="minimum">
-      <double>-300.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>300.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="1">
-    <widget class="ctkRangeSlider" name="pandRange">
-     <property name="minimum">
-      <number>-160</number>
-     </property>
-     <property name="maximum">
-      <number>40</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="minimumValue">
-      <number>-70</number>
-     </property>
-     <property name="minimumPosition">
-      <number>-70</number>
-     </property>
-     <property name="maximumPosition">
-      <number>-10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1">
-    <widget class="ctkRangeSlider" name="wfRange">
-     <property name="minimum">
-      <number>-160</number>
-     </property>
-     <property name="maximum">
-      <number>40</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="minimumValue">
-      <number>-70</number>
-     </property>
-     <property name="maximumPosition">
-      <number>-10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="text">
-      <string>Wf. dB</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="0">
-    <widget class="QLabel" name="label_12">
-     <property name="text">
-      <string>Freq zoom</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="1">
-    <widget class="QSlider" name="freqZoomSlider">
-     <property name="minimum">
-      <number>-900</number>
-     </property>
-     <property name="maximum">
-      <number>900</number>
-     </property>
-     <property name="value">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Zero adjust</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="fftSizeCombo">
-     <item>
-      <property name="text">
-       <string>Default</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>512</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>1024</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>2048</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>4096</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>8192</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>16384</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>32768</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>65536</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QComboBox" name="unitsCombo"/>
-   </item>
-   <item row="7" column="1">
-    <widget class="ContextAwareSpinBox" name="zeroPointSpin">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="suffix">
-      <string> dBFS</string>
-     </property>
-     <property name="minimum">
-      <double>-300.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>300.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="2">
-    <widget class="QLabel" name="freqZoomLabel">
-     <property name="minimumSize">
-      <size>
-       <width>31</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>1x</string>
-     </property>
-    </widget>
-   </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Window</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>FFT size</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Spect/Wf</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="19" column="0">
-    <widget class="QLabel" name="label_17">
-     <property name="text">
-      <string>Palette</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="1">
-    <widget class="QWidget" name="widget" native="true">
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <property name="spacing">
-       <number>0</number>
-      </property>
-     </layout>
-    </widget>
-   </item>
-   <item row="16" column="0" colspan="3">
-    <widget class="QWidget" name="widget_2" native="true">
-     <layout class="QGridLayout" name="gridLayout_5">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <property name="horizontalSpacing">
-       <number>1</number>
-      </property>
-      <property name="verticalSpacing">
-       <number>0</number>
-      </property>
-      <item row="0" column="3">
-       <widget class="QPushButton" name="timeStampsButton">
-        <property name="text">
-         <string>&amp;Time stamps</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QPushButton" name="bookmarksButton">
-        <property name="text">
-         <string>&amp;Bookmarks</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="channelButton">
-        <property name="text">
-         <string>&amp;Channels</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="17" column="1">
-    <widget class="QComboBox" name="timeZoneCombo">
-     <item>
-      <property name="text">
-       <string>Local time</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Universal Time (UTC)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="19" column="1">
-    <widget class="QComboBox" name="paletteCombo">
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>64</width>
-       <height>20</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>Pand. dB</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="1">
-    <widget class="QWidget" name="widget_4" native="true">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>42</height>
-      </size>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_6">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QPushButton" name="detectPeakButton">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>&amp;Detect</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="holdPeakButton">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>&amp;Hold</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Units</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Time span</string>
@@ -755,77 +816,36 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_13">
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_10">
      <property name="text">
-      <string>Gain</string>
+      <string>Pand. dB</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="14" column="1" colspan="2">
-    <widget class="QCheckBox" name="lockButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>&amp;Lock spectrum and waterfall</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
+   <item row="7" column="1">
+    <widget class="QComboBox" name="unitsCombo"/>
    </item>
-   <item row="9" column="1">
-    <widget class="QWidget" name="widget_3" native="true">
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <property name="horizontalSpacing">
-       <number>3</number>
-      </property>
-      <property name="verticalSpacing">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="SciSpinBox" name="avgSpinBox">
-        <property name="minimum">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>1000000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="label_15">
-        <property name="text">
-         <string>FFTs</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_16">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_19">
      <property name="text">
-      <string>RBW</string>
+      <string>Coverage</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="coverageLabel">
+     <property name="text">
+      <string>N/A</string>
+     </property>
+     <property name="indent">
+      <number>2</number>
      </property>
     </widget>
    </item>

--- a/Default/FFT/FFTWidget.ui
+++ b/Default/FFT/FFTWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>323</width>
-    <height>452</height>
+    <height>563</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -82,7 +82,10 @@
    <item row="2" column="1">
     <widget class="QLabel" name="rbwLabel">
      <property name="text">
-      <string>RBW: N/A</string>
+      <string>N/A</string>
+     </property>
+     <property name="indent">
+      <number>2</number>
      </property>
     </widget>
    </item>
@@ -814,6 +817,16 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="text">
+      <string>RBW</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
It's useful to know what fraction of a signal is being shown in the waterfall so that you know if it's possible for any bursts to be missed (coverage <100%) or if data is getting smeared across multiple waterfall lines (coverage >100%).